### PR TITLE
Specify entry point for Docker containers

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -214,3 +214,13 @@ trace {
     enabled = true
     file    = "${params.baseDirReport}/tracing/${timestamp}_trace.html"
 }
+
+
+/*
+    Specify entry point for Docker containers
+*/
+
+docker {
+    runOptions = '--entrypoint=""'
+}
+


### PR DESCRIPTION
Nextflow>=22.08.0 does not automatically use /bin/bash as the entry point